### PR TITLE
Build + upload wheel in CI

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "schedule:weekly"
+  ],
+  "timezone": "America/Los_Angeles",
+  "includePaths": [".github/**"]
+}

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -1,0 +1,36 @@
+name: build_wheel
+on: [push]
+permissions: read-all
+jobs:
+  build_wheel:
+    strategy:
+      matrix:
+        python-version:
+          - 3.12.6
+    runs-on: [self-hosted, fasttext]
+    steps:
+    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
+    - name: Install Python
+      run: |
+        uv python install ${{ matrix.python-version }}
+    - name: Create virtual environment
+      run: |
+        rm -rf venv
+        uv venv --python ${{ matrix.python-version }} venv
+        echo "$(pwd)/venv/bin" >> $GITHUB_PATH
+    - name: Build wheel
+      run: |
+        rm -rf dist
+        uv build --out-dir dist
+    - name: Check wheel
+      run: |
+        # These requirements were lifted from `install_requires` in `setup.py`.
+        uv pip install \
+          'pybind11>=2.2' \
+          'setuptools>=0.7.0' \
+          'numpy'
+        uv pip install --no-index --find-links dist fasttext
+        python -c 'import fasttext'
+    - name: Upload wheel
+      run: |
+        ./upload-wheel.sh dist/fasttext*.whl

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+* @Everlaw/developer-experience-squad

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import subprocess
 import platform
 import io
 
-__version__ = "0.9.3"
+__version__ = "0.9.4.rc0"
 FASTTEXT_SRC = "src"
 
 # Based on https://github.com/pybind/python_example

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import subprocess
 import platform
 import io
 
-__version__ = "0.9.2"
+__version__ = "0.9.3"
 FASTTEXT_SRC = "src"
 
 # Based on https://github.com/pybind/python_example

--- a/setup.py
+++ b/setup.py
@@ -194,6 +194,7 @@ setup(
         "Operating System :: Unix",
         "Operating System :: MacOS",
     ],
+    # These requirements are duplicated in `.github/workflows/build_wheel.yml`.
     install_requires=["pybind11>=2.2", "setuptools >= 0.7.0", "numpy"],
     cmdclass={"build_ext": BuildExt},
     packages=[

--- a/upload-wheel.sh
+++ b/upload-wheel.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+wheel="$1"
+url="s3://everlaw-build-artifacts/fasttext/$(basename "$wheel")"
+
+if aws s3 ls "$url" &>/dev/null; then
+    >&2 echo "$url already exists!"
+    exit 0
+fi
+
+aws s3 cp --only-show-errors "$wheel" "$url"
+>&2 echo "Uploaded $url"


### PR DESCRIPTION
As discussed in https://podio.com/easyesicom/feature-roadmap/apps/postmortem/items/260, `fasttext` is currently using the deprecated
```yaml
description-file: ...
```
syntax, which will eventually be upgraded to an error in `setuptools`.

By forking this (archived by upstream) repo and uploading our own wheel to S3, our internal pipelines can install a wheel that doesn't have this issue.

Getting this to all work together requires a few PRs into [`Everlaw/servers`](https://github.com/Everlaw/servers):
* https://github.com/Everlaw/servers/pull/39903
* https://github.com/Everlaw/servers/pull/39904
* https://github.com/Everlaw/servers/pull/39905

See also: https://podio.com/easyesicom/feature-roadmap/apps/security-impact-analysis/items/1120.