### PR TITLE
Build and upload Python 3.13 wheel

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -7,6 +7,7 @@ jobs:
       matrix:
         python-version:
           - 3.12.6
+          - 3.13.12
     runs-on: [self-hosted, fasttext]
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Build wheel
       run: |
         rm -rf dist
-        uv build --out-dir dist
+        uv build --python ${{ matrix.python-version }} --out-dir dist
     - name: Check wheel
       run: |
         # These requirements were lifted from `install_requires` in `setup.py`.


### PR DESCRIPTION

## Description

Adds Python 3.13.12 to the `build_wheel` matrix alongside 3.12.6, so we start publishing `cp313` wheels. This is a prerequisite for upgrading `servers` to Python 3.13.

Also pins the `uv build` interpreter to the matrix Python version. `uv build` ignores the activated venv and uses the newest Python installed on the runner, which only worked before because a single version was installed; with two versions in the matrix, both jobs would otherwise build `cp313` wheels.

## Jira, Podio Bug or Trello Card Link:

https://everlaw.atlassian.net/browse/PE-791

## Testing Procedure or Link:

- [x] `build_wheel` workflow runs on this branch and both matrix jobs (3.12.6 and 3.13.12) pass, including the `import fasttext` wheel check
- [x] `fasttext-0.9.5-cp313-cp313-linux_x86_64.whl` (and `.sig`) appear in `s3://everlaw-artifacts/fasttext/`
- [x] The 3.12 job reports "already exists" for the current `cp312` wheel and does not fail

## Link to SIA (N/A if None):

https://everlaw.atlassian.net/browse/SIA-5951
